### PR TITLE
feat: add OptiScaler nightly channel and version dropdown

### DIFF
--- a/Helpers/BulkGamepadNavigationHelper.cs
+++ b/Helpers/BulkGamepadNavigationHelper.cs
@@ -85,7 +85,7 @@ public class BulkGamepadNavigationHelper : GamepadHelperBase, IDisposable
                         }
                     }
                     
-                    if (focused?.Name == "BtnOptiStable" || focused?.Name == "BtnOptiBeta" || focused?.Name == "BtnOptiCustom")
+                    if (focused?.Name == "BtnOptiStable" || focused?.Name == "BtnOptiBeta" || focused?.Name == "BtnOptiNightly" || focused?.Name == "BtnOptiCustom")
                     {
                         var cmb = _window.FindControl<ComboBox>("CmbOptiVersion");
                         cmb?.Focus(NavigationMethod.Directional);
@@ -144,13 +144,27 @@ public class BulkGamepadNavigationHelper : GamepadHelperBase, IDisposable
                     {
                         _window.FindControl<Control>("BtnOptiStable")?.Focus(NavigationMethod.Directional);
                     }
-                    else if (focused?.Name == "BtnOptiCustom")
+                    else if (focused?.Name == "BtnOptiNightly")
                     {
                         var btnBeta = _window.FindControl<Control>("BtnOptiBeta");
                         if (btnBeta != null && btnBeta.IsVisible)
                             btnBeta.Focus(NavigationMethod.Directional);
                         else
                             _window.FindControl<Control>("BtnOptiStable")?.Focus(NavigationMethod.Directional);
+                    }
+                    else if (focused?.Name == "BtnOptiCustom")
+                    {
+                        var btnNightly = _window.FindControl<Control>("BtnOptiNightly");
+                        if (btnNightly != null && btnNightly.IsVisible)
+                            btnNightly.Focus(NavigationMethod.Directional);
+                        else
+                        {
+                            var btnBeta = _window.FindControl<Control>("BtnOptiBeta");
+                            if (btnBeta != null && btnBeta.IsVisible)
+                                btnBeta.Focus(NavigationMethod.Directional);
+                            else
+                                _window.FindControl<Control>("BtnOptiStable")?.Focus(NavigationMethod.Directional);
+                        }
                     }
                     else
                     {
@@ -173,6 +187,29 @@ public class BulkGamepadNavigationHelper : GamepadHelperBase, IDisposable
                                 btnBeta.Focus(NavigationMethod.Directional);
                             else
                             {
+                                var btnNightly = _window.FindControl<Control>("BtnOptiNightly");
+                                if (btnNightly != null && btnNightly.IsVisible)
+                                    btnNightly.Focus(NavigationMethod.Directional);
+                                else
+                                {
+                                    var btnCustom = _window.FindControl<Control>("BtnOptiCustom");
+                                    if (btnCustom != null && btnCustom.IsVisible)
+                                        btnCustom.Focus(NavigationMethod.Directional);
+                                    else
+                                    {
+                                        _lastSidebarFocus = focused;
+                                        FocusFirstGame();
+                                    }
+                                }
+                            }
+                        }
+                        else if (focused?.Name == "BtnOptiBeta")
+                        {
+                            var btnNightly = _window.FindControl<Control>("BtnOptiNightly");
+                            if (btnNightly != null && btnNightly.IsVisible)
+                                btnNightly.Focus(NavigationMethod.Directional);
+                            else
+                            {
                                 var btnCustom = _window.FindControl<Control>("BtnOptiCustom");
                                 if (btnCustom != null && btnCustom.IsVisible)
                                     btnCustom.Focus(NavigationMethod.Directional);
@@ -183,7 +220,7 @@ public class BulkGamepadNavigationHelper : GamepadHelperBase, IDisposable
                                 }
                             }
                         }
-                        else if (focused?.Name == "BtnOptiBeta")
+                        else if (focused?.Name == "BtnOptiNightly")
                         {
                             var btnCustom = _window.FindControl<Control>("BtnOptiCustom");
                             if (btnCustom != null && btnCustom.IsVisible)

--- a/Helpers/VersionComparer.cs
+++ b/Helpers/VersionComparer.cs
@@ -1,0 +1,214 @@
+// OptiScaler Client - A frontend for managing OptiScaler installations
+// Copyright (C) 2026 Agustín Montaña (Agustinm28)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace OptiscalerClient.Helpers
+{
+    /// <summary>
+    /// Unified version comparer that accurately sorts standard SemVer releases,
+    /// prereleases (alpha, pre, beta, rc), build-numbered releases, and nightly builds (nightly-YYYYMMDD).
+    /// Returns &gt; 0 if x is newer than y, &lt; 0 if x is older than y, and 0 if equal.
+    /// Used with OrderByDescending(v =&gt; v, VersionComparer.Instance) for newest-to-oldest ordering.
+    /// </summary>
+    public class VersionComparer : IComparer<string>
+    {
+        public static readonly VersionComparer Instance = new();
+
+        public int Compare(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x == null) return -1;
+            if (y == null) return 1;
+
+            // "rolling" or "latest" keyword always ranks highest
+            bool xRolling = string.Equals(x, "rolling", StringComparison.OrdinalIgnoreCase) || string.Equals(x, "latest", StringComparison.OrdinalIgnoreCase);
+            bool yRolling = string.Equals(y, "rolling", StringComparison.OrdinalIgnoreCase) || string.Equals(y, "latest", StringComparison.OrdinalIgnoreCase);
+            if (xRolling != yRolling) return xRolling ? 1 : -1;
+            if (xRolling && yRolling) return 0;
+
+            bool xNightly = IsNightly(x);
+            bool yNightly = IsNightly(y);
+            if (xNightly && yNightly)
+            {
+                return CompareNightly(x, y);
+            }
+            if (xNightly != yNightly)
+            {
+                return CompareNightlyVsStandard(x, y);
+            }
+
+            return CompareStandard(x, y);
+        }
+
+        public static bool IsNightly(string v)
+        {
+            return v.Contains("nightly", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int CompareNightly(string x, string y)
+        {
+            // Extract 8-digit date YYYYMMDD if present (e.g. nightly-20260910)
+            var matchX = Regex.Match(x, @"\d{8}");
+            var matchY = Regex.Match(y, @"\d{8}");
+
+            if (matchX.Success && matchY.Success)
+            {
+                if (long.TryParse(matchX.Value, out long dateX) && long.TryParse(matchY.Value, out long dateY))
+                {
+                    int dateComp = dateX.CompareTo(dateY);
+                    if (dateComp != 0) return dateComp;
+                }
+            }
+            else if (matchX.Success)
+            {
+                // x has a date (modern nightly), y does not (legacy tag like 0.7-old_nightly or nightly)
+                return 1;
+            }
+            else if (matchY.Success)
+            {
+                return -1;
+            }
+
+            // If neither has an 8-digit date, compare numeric version parts (e.g. 0.7 vs unversioned)
+            var verX = ExtractVersionComponents(x);
+            var verY = ExtractVersionComponents(y);
+            int comp = CompareNumericParts(verX.Numbers, verY.Numbers);
+            if (comp != 0) return comp;
+
+            return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int CompareNightlyVsStandard(string x, string y)
+        {
+            var verX = ExtractVersionComponents(x);
+            var verY = ExtractVersionComponents(y);
+            int comp = CompareNumericParts(verX.Numbers, verY.Numbers);
+            if (comp != 0) return comp;
+            return IsNightly(x) ? -1 : 1;
+        }
+
+        private static int CompareStandard(string x, string y)
+        {
+            var parsedX = ExtractVersionComponents(x);
+            var parsedY = ExtractVersionComponents(y);
+
+            // Compare major.minor.patch.build numeric segments
+            int numComp = CompareNumericParts(parsedX.Numbers, parsedY.Numbers);
+            if (numComp != 0) return numComp;
+
+            // Numeric parts are identical (e.g. 0.9.5 vs 0.9.5-pre4 vs 0.9.5-beta1)
+            bool xHasSuffix = !string.IsNullOrEmpty(parsedX.Suffix);
+            bool yHasSuffix = !string.IsNullOrEmpty(parsedY.Suffix);
+
+            if (!xHasSuffix && yHasSuffix) return 1;  // Pure stable 0.9.5 > 0.9.5-pre4
+            if (xHasSuffix && !yHasSuffix) return -1; // 0.9.5-pre4 < Pure stable 0.9.5
+            if (xHasSuffix && yHasSuffix)
+            {
+                int stageX = GetPrereleaseStageRank(parsedX.Suffix);
+                int stageY = GetPrereleaseStageRank(parsedY.Suffix);
+                if (stageX != stageY) return stageX.CompareTo(stageY);
+
+                // Same prerelease stage: compare trailing numeric index (e.g. pre4 vs pre3, pre66 vs pre9)
+                int numX = ExtractTrailingNumber(parsedX.Suffix);
+                int numY = ExtractTrailingNumber(parsedY.Suffix);
+                if (numX != numY) return numX.CompareTo(numY);
+
+                return string.Compare(parsedX.Suffix, parsedY.Suffix, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static (List<int> Numbers, string Suffix) ExtractVersionComponents(string v)
+        {
+            var trimmed = v.Trim().TrimStart('v', 'V', '.');
+            int splitIdx = -1;
+            for (int i = 0; i < trimmed.Length; i++)
+            {
+                char c = trimmed[i];
+                if (c == '-' || c == '+')
+                {
+                    splitIdx = i;
+                    break;
+                }
+                if (char.IsLetter(c))
+                {
+                    splitIdx = i;
+                    break;
+                }
+            }
+
+            string numPart = splitIdx >= 0 ? trimmed.Substring(0, splitIdx).TrimEnd('.') : trimmed;
+            string suffix = splitIdx >= 0 ? trimmed.Substring(splitIdx).TrimStart('-', '+') : string.Empty;
+
+            var numbers = new List<int>();
+            if (!string.IsNullOrEmpty(numPart))
+            {
+                var segments = numPart.Split('.');
+                foreach (var seg in segments)
+                {
+                    if (int.TryParse(seg, out int n))
+                    {
+                        numbers.Add(n);
+                    }
+                    else
+                    {
+                        var m = Regex.Match(seg, @"^\d+");
+                        if (m.Success && int.TryParse(m.Value, out int mn))
+                            numbers.Add(mn);
+                        else
+                            numbers.Add(0);
+                    }
+                }
+            }
+
+            return (numbers, suffix);
+        }
+
+        private static int CompareNumericParts(List<int> a, List<int> b)
+        {
+            int maxLen = Math.Max(a.Count, b.Count);
+            for (int i = 0; i < maxLen; i++)
+            {
+                int valA = i < a.Count ? a[i] : 0;
+                int valB = i < b.Count ? b[i] : 0;
+                if (valA != valB) return valA.CompareTo(valB);
+            }
+            return 0;
+        }
+
+        private static int GetPrereleaseStageRank(string suffix)
+        {
+            var lower = suffix.ToLowerInvariant();
+            if (lower.Contains("rc")) return 4;
+            if (lower.Contains("beta")) return 3;
+            if (lower.Contains("pre")) return 2;
+            if (lower.Contains("alpha")) return 1;
+            return 0;
+        }
+
+        private static int ExtractTrailingNumber(string s)
+        {
+            var match = Regex.Match(s, @"\d+");
+            if (match.Success && int.TryParse(match.Value, out int val))
+                return val;
+            return 0;
+        }
+    }
+}

--- a/Models/AppConfiguration.cs
+++ b/Models/AppConfiguration.cs
@@ -90,6 +90,7 @@ namespace OptiscalerClient.Models
         public RepositoryConfig App { get; set; } = new();
         public RepositoryConfig OptiScaler { get; set; } = new();
         public RepositoryConfig OptiScalerBetas { get; set; } = new();
+        public RepositoryConfig OptiScalerNightlies { get; set; } = new();
         public RepositoryConfig OptiScalerExtras { get; set; } = new();
         public RepositoryConfig Fakenvapi { get; set; } = new();
         public RepositoryConfig NukemFG { get; set; } = new();
@@ -222,8 +223,10 @@ namespace OptiscalerClient.Models
         public string Version { get; set; } = string.Empty;
         public string? DownloadUrl { get; set; }
         public bool IsBeta { get; set; }
+        public bool IsNightly { get; set; }
         public bool IsLatestStable { get; set; }
         public bool IsLatestBeta { get; set; }
+        public bool IsLatestNightly { get; set; }
     }
 
     /// <summary>

--- a/Services/ComponentManagementService.cs
+++ b/Services/ComponentManagementService.cs
@@ -53,7 +53,9 @@ namespace OptiscalerClient.Services
 
         private static System.Collections.Generic.List<string>? _cachedOptiScalerVersions = null;
         private static System.Collections.Generic.HashSet<string> _cachedBetaVersions = new();
+        private static System.Collections.Generic.HashSet<string> _cachedNightlyVersions = new();
         private static string? _cachedLatestBetaVersion = null;
+        private static string? _cachedLatestNightlyVersion = null;
         private static string? _cachedLatestStableVersion = null;
         private static string? _cachedFakenvapiVersion = null;
         private static string? _cachedNukemFGVersion = null;
@@ -92,6 +94,7 @@ namespace OptiscalerClient.Services
             }
         }
         public System.Collections.Generic.HashSet<string> BetaVersions => _cachedBetaVersions;
+        public System.Collections.Generic.HashSet<string> NightlyVersions => _cachedNightlyVersions;
 
         /// <summary>
         /// Effective OptiScaler default: null when auto-latest is on (callers already fall back to the
@@ -100,7 +103,18 @@ namespace OptiscalerClient.Services
         public string? EffectiveDefaultOptiScalerVersion =>
             Config.AutoLatestOptiScalerDefault ? null : Config.DefaultOptiScalerVersion;
         public string? LatestBetaVersion => _cachedLatestBetaVersion;
+        public string? LatestNightlyVersion => _cachedLatestNightlyVersion;
         public string? LatestStableVersion => _cachedLatestStableVersion;
+
+        public bool IsNightlyVersion(string version) =>
+            _cachedNightlyVersions.Contains(version) || version.Contains("nightly", StringComparison.OrdinalIgnoreCase);
+
+        public bool IsBetaVersion(string version) =>
+            _cachedBetaVersions.Contains(version) || (!IsNightlyVersion(version) && (
+                version.Contains("-beta", StringComparison.OrdinalIgnoreCase) ||
+                version.Contains("-pre", StringComparison.OrdinalIgnoreCase) ||
+                version.Contains("-rc", StringComparison.OrdinalIgnoreCase) ||
+                version.Contains("-alpha", StringComparison.OrdinalIgnoreCase)));
 
         /// <summary>All available OptiScaler Extras (FSR4 INT8 mod) versions: remote releases plus any
         /// custom packages imported via ImportCustomExtrasArchiveAsync.</summary>
@@ -190,11 +204,15 @@ namespace OptiscalerClient.Services
                         _config = JsonSerializer.Deserialize(json, OptimizerContext.Default.AppConfiguration) ?? new();
                         System.Diagnostics.Debug.WriteLine($"[Config] Loaded from AppData: {_configFile}");
 
-                        // If core repos are empty (e.g. config was generated with blank defaults),
-                        // merge them from the install-dir template so the app stays functional.
-                        // Also re-merge if any individual repo is missing (e.g. OptiPatcher added in a later version).
-                        bool needsMerge = string.IsNullOrEmpty(_config.OptiScaler.RepoOwner)
-                                       || string.IsNullOrEmpty(_config.OptiPatcher.RepoOwner);
+                        // If any core repo is missing or empty (e.g. config was generated with blank defaults,
+                        // or a repo like OptiScalerNightlies was added in an update), merge them from the template.
+                        bool needsMerge = string.IsNullOrEmpty(_config.OptiScaler?.RepoOwner)
+                                       || string.IsNullOrEmpty(_config.OptiPatcher?.RepoOwner)
+                                       || string.IsNullOrEmpty(_config.OptiScalerBetas?.RepoOwner)
+                                       || string.IsNullOrEmpty(_config.OptiScalerNightlies?.RepoOwner)
+                                       || string.IsNullOrEmpty(_config.OptiScalerExtras?.RepoOwner)
+                                       || string.IsNullOrEmpty(_config.Fakenvapi?.RepoOwner)
+                                       || string.IsNullOrEmpty(_config.NukemFG?.RepoOwner);
                         if (needsMerge)
                         {
                             MergeReposFromTemplate(_config);
@@ -254,22 +272,35 @@ namespace OptiscalerClient.Services
                                      : File.Exists(baseDirConfig)    ? baseDirConfig
                                      : null;
 
-                if (templatePath == null) return;
+                if (templatePath != null)
+                {
+                    var json     = File.ReadAllText(templatePath);
+                    var template = JsonSerializer.Deserialize(json, OptimizerContext.Default.AppConfiguration);
+                    if (template != null)
+                    {
+                        if (!string.IsNullOrEmpty(template.App?.RepoOwner))            target.App            = template.App;
+                        if (!string.IsNullOrEmpty(template.OptiScaler?.RepoOwner))     target.OptiScaler     = template.OptiScaler;
+                        if (!string.IsNullOrEmpty(template.OptiScalerBetas?.RepoOwner))target.OptiScalerBetas= template.OptiScalerBetas;
+                        if (!string.IsNullOrEmpty(template.OptiScalerNightlies?.RepoOwner))target.OptiScalerNightlies= template.OptiScalerNightlies;
+                        if (!string.IsNullOrEmpty(template.OptiScalerExtras?.RepoOwner))target.OptiScalerExtras = template.OptiScalerExtras;
+                        if (!string.IsNullOrEmpty(template.Fakenvapi?.RepoOwner))      target.Fakenvapi      = template.Fakenvapi;
+                        if (!string.IsNullOrEmpty(template.NukemFG?.RepoOwner))        target.NukemFG        = template.NukemFG;
+                        if (!string.IsNullOrEmpty(template.OptiPatcher?.RepoOwner))    target.OptiPatcher    = template.OptiPatcher;
 
-                var json     = File.ReadAllText(templatePath);
-                var template = JsonSerializer.Deserialize(json, OptimizerContext.Default.AppConfiguration);
-                if (template == null) return;
+                        if (target.ScanExclusions.Count == 0 && template.ScanExclusions.Count > 0)
+                            target.ScanExclusions = template.ScanExclusions;
+                    }
+                }
 
-                if (!string.IsNullOrEmpty(template.App.RepoOwner))            target.App            = template.App;
-                if (!string.IsNullOrEmpty(template.OptiScaler.RepoOwner))     target.OptiScaler     = template.OptiScaler;
-                if (!string.IsNullOrEmpty(template.OptiScalerBetas.RepoOwner))target.OptiScalerBetas= template.OptiScalerBetas;
-                if (!string.IsNullOrEmpty(template.OptiScalerExtras.RepoOwner))target.OptiScalerExtras = template.OptiScalerExtras;
-                if (!string.IsNullOrEmpty(template.Fakenvapi.RepoOwner))      target.Fakenvapi      = template.Fakenvapi;
-                if (!string.IsNullOrEmpty(template.NukemFG.RepoOwner))        target.NukemFG        = template.NukemFG;
-                if (!string.IsNullOrEmpty(template.OptiPatcher.RepoOwner))    target.OptiPatcher    = template.OptiPatcher;
-
-                if (target.ScanExclusions.Count == 0 && template.ScanExclusions.Count > 0)
-                    target.ScanExclusions = template.ScanExclusions;
+                // Guaranteed fallbacks if not populated
+                if (string.IsNullOrEmpty(target.OptiScalerNightlies?.RepoOwner))
+                    target.OptiScalerNightlies = new RepositoryConfig { RepoOwner = "optiscaler", RepoName = "OptiScaler-nightly" };
+                if (string.IsNullOrEmpty(target.OptiScalerBetas?.RepoOwner))
+                    target.OptiScalerBetas = new RepositoryConfig { RepoOwner = "Optiscaler-Client", RepoName = "OptiScaler-Betas" };
+                if (string.IsNullOrEmpty(target.OptiScaler?.RepoOwner))
+                    target.OptiScaler = new RepositoryConfig { RepoOwner = "optiscaler", RepoName = "OptiScaler" };
+                if (string.IsNullOrEmpty(target.OptiPatcher?.RepoOwner))
+                    target.OptiPatcher = new RepositoryConfig { RepoOwner = "optiscaler", RepoName = "OptiPatcher" };
             }
             catch (Exception ex)
         {
@@ -405,9 +436,7 @@ namespace OptiscalerClient.Services
             _cachedExtrasVersions = _extrasCache.Releases
                 .Select(r => r.Version)
                 .Distinct()
-                .OrderByDescending(ParseVersionForSort)
-                .ThenByDescending(ParseVersionSuffixValue)
-                .ThenByDescending(v => v, StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(v => v, VersionComparer.Instance)
                 .ToList();
             DebugWindow.Log($"[ExtrasCache] Rebuilt in-memory: {_cachedExtrasVersions.Count} version(s), latest={_cachedLatestExtrasVersion}");
         }
@@ -427,6 +456,7 @@ namespace OptiscalerClient.Services
             {
                 existing.IsLatestStable = false;
                 existing.IsLatestBeta = false;
+                existing.IsLatestNightly = false;
             }
 
             foreach (var entry in newEntries)
@@ -447,32 +477,14 @@ namespace OptiscalerClient.Services
                             existing.DownloadUrl = entry.DownloadUrl;
                         existing.IsLatestStable = entry.IsLatestStable;
                         existing.IsLatestBeta = entry.IsLatestBeta;
+                        existing.IsLatestNightly = entry.IsLatestNightly;
                         existing.IsBeta = entry.IsBeta;
+                        existing.IsNightly = entry.IsNightly;
                     }
                 }
             }
 
             _releasesCache.LastUpdated = DateTime.Now;
-        }
-
-        /// <summary>
-        /// Rebuilds the static in-memory version lists from the persistent releases cache.
-        /// </summary>
-        /// <summary>Parses the leading numeric dotted portion of a version string (e.g. "v1.2.3-beta" → 1.2.3) for descending sort.</summary>
-        private static Version ParseVersionForSort(string v)
-        {
-            if (string.IsNullOrEmpty(v)) return new Version(0, 0);
-            var clean = new string(v.TakeWhile(c => char.IsDigit(c) || c == '.').ToArray()).TrimEnd('.');
-            if (!string.IsNullOrEmpty(clean) && Version.TryParse(clean, out var parsed)) return parsed;
-            return new Version(0, 0);
-        }
-
-        /// <summary>Trailing numeric suffix (e.g. build/patch number) used as a tiebreaker after ParseVersionForSort.</summary>
-        private static int ParseVersionSuffixValue(string v)
-        {
-            var match = System.Text.RegularExpressions.Regex.Match(v, @"\d+$");
-            if (match.Success && int.TryParse(match.Value, out int val)) return val;
-            return 0;
         }
 
         private void RebuildInMemoryCacheFromReleases()
@@ -481,36 +493,44 @@ namespace OptiscalerClient.Services
 
             var all = _releasesCache.Releases;
 
-            var stablesList = all.Where(r => !r.IsBeta)
-                                 .OrderByDescending(r => ParseVersionForSort(r.Version))
-                                 .ThenByDescending(r => ParseVersionSuffixValue(r.Version))
-                                 .ThenByDescending(r => r.Version, StringComparer.OrdinalIgnoreCase)
+            var stablesList = all.Where(r => !r.IsBeta && !r.IsNightly && !IsBetaVersion(r.Version) && !IsNightlyVersion(r.Version))
+                                 .Select(r => r.Version)
+                                 .Distinct()
+                                 .OrderByDescending(v => v, VersionComparer.Instance)
                                  .ToList();
 
-            var betasList = all.Where(r => r.IsBeta)
-                               .OrderByDescending(r => ParseVersionForSort(r.Version))
-                               .ThenByDescending(r => ParseVersionSuffixValue(r.Version))
-                               .ThenByDescending(r => r.Version, StringComparer.OrdinalIgnoreCase)
+            var betasList = all.Where(r => (r.IsBeta || IsBetaVersion(r.Version)) && !r.IsNightly && !IsNightlyVersion(r.Version))
+                               .Select(r => r.Version)
+                               .Distinct()
+                               .OrderByDescending(v => v, VersionComparer.Instance)
                                .ToList();
 
+            var nightliesList = all.Where(r => r.IsNightly || IsNightlyVersion(r.Version))
+                                   .Select(r => r.Version)
+                                   .Distinct()
+                                   .OrderByDescending(v => v, VersionComparer.Instance)
+                                   .ToList();
+
             _cachedBetaVersions = new System.Collections.Generic.HashSet<string>(
-                betasList.Select(r => r.Version), StringComparer.OrdinalIgnoreCase);
+                betasList, StringComparer.OrdinalIgnoreCase);
 
-            _cachedLatestBetaVersion = all.FirstOrDefault(r => r.IsLatestBeta)?.Version
-                ?? betasList.FirstOrDefault()?.Version;
+            _cachedNightlyVersions = new System.Collections.Generic.HashSet<string>(
+                nightliesList, StringComparer.OrdinalIgnoreCase);
 
-            _cachedLatestStableVersion = all.FirstOrDefault(r => r.IsLatestStable)?.Version
-                ?? stablesList.FirstOrDefault()?.Version;
+            _cachedLatestBetaVersion = betasList.FirstOrDefault();
+            _cachedLatestNightlyVersion = nightliesList.FirstOrDefault();
+            _cachedLatestStableVersion = stablesList.FirstOrDefault();
 
-            // Stable versions first (highest to lowest), then betas (highest to lowest)
+            // Stable versions first (highest to lowest), then betas, then nightlies
             var merged = new System.Collections.Generic.List<string>();
-            merged.AddRange(stablesList.Select(r => r.Version));
-            merged.AddRange(betasList.Select(r => r.Version));
+            merged.AddRange(stablesList);
+            merged.AddRange(betasList);
+            merged.AddRange(nightliesList);
 
             if (merged.Count > 0)
                 _cachedOptiScalerVersions = merged.Distinct().ToList();
 
-            DebugWindow.Log($"[ReleasesCache] Rebuilt in-memory cache: {stablesList.Count} stable + {betasList.Count} beta versions");
+            DebugWindow.Log($"[ReleasesCache] Rebuilt in-memory cache: {stablesList.Count} stable + {betasList.Count} beta + {nightliesList.Count} nightly versions");
         }
 
         // ── Download helpers ─────────────────────────────────────────────────────
@@ -608,7 +628,9 @@ namespace OptiscalerClient.Services
                     ? _config.LastApiCheckTime.Value
                     : _lastApiCheckTime;
 
-                if ((_cachedOptiScalerVersions == null || _cachedOptiScalerVersions.Count == 0) ||
+                bool hasFetchedNightlies = _cachedNightlyVersions.Any(v => v.StartsWith("nightly-", StringComparison.OrdinalIgnoreCase));
+                bool cacheMissingNightly = !hasFetchedNightlies && !string.IsNullOrEmpty(_config.OptiScalerNightlies?.RepoOwner);
+                if ((_cachedOptiScalerVersions == null || _cachedOptiScalerVersions.Count == 0 || cacheMissingNightly) ||
                     (DateTime.Now - lastCheck).TotalMinutes > 15)
                 {
                     DebugWindow.Log($"[ComponentCheck] Fetching updates from GitHub API (last check: {(DateTime.Now - lastCheck).ToString(@"hh\:mm\:ss")} ago)");
@@ -627,17 +649,20 @@ namespace OptiscalerClient.Services
                         await Task.Delay(150);
                         var optiBetasTask = FetchAllReleasesWithUrlAsync(_config.OptiScalerBetas, isBeta: true);
                         await Task.Delay(150);
+                        var optiNightliesTask = FetchAllReleasesWithUrlAsync(_config.OptiScalerNightlies, isBeta: false, isNightly: true);
+                        await Task.Delay(150);
                         var fakeTask = FetchFakenvapiReleasesAsync();
                         await Task.Delay(150);
                         var extrasTask = FetchExtrasReleasesAsync();
                         await Task.Delay(150);
                         var optiPatcherTask = FetchOptiPatcherReleasesAsync();
 
-                        await Task.WhenAll(optiVersionsTask, optiBetasTask, fakeTask, extrasTask, optiPatcherTask);
+                        await Task.WhenAll(optiVersionsTask, optiBetasTask, optiNightliesTask, fakeTask, extrasTask, optiPatcherTask);
 
                         var stableEntries = await optiVersionsTask;
                         var betaEntries = await optiBetasTask;
-                        var allNewEntries = stableEntries.Concat(betaEntries).ToList();
+                        var nightlyEntries = await optiNightliesTask;
+                        var allNewEntries = stableEntries.Concat(betaEntries).Concat(nightlyEntries).ToList();
 
                         if (allNewEntries.Count > 0)
                         {
@@ -801,22 +826,22 @@ namespace OptiscalerClient.Services
         }
 
         private async Task<System.Collections.Generic.List<OptiScalerReleaseEntry>> FetchAllReleasesWithUrlAsync(
-            RepositoryConfig config, bool isBeta)
+            RepositoryConfig? config, bool isBeta, bool isNightly = false)
         {
             var entries = new System.Collections.Generic.List<OptiScalerReleaseEntry>();
+            if (config == null || string.IsNullOrEmpty(config.RepoOwner) || string.IsNullOrEmpty(config.RepoName))
+            {
+                return entries;
+            }
             var repoLabel = $"{config.RepoOwner}/{config.RepoName}";
             bool latestStableMarked = false;
             bool latestBetaMarked = false;
+            bool latestNightlyMarked = false;
 
             try
             {
-                if (string.IsNullOrEmpty(config.RepoOwner) || string.IsNullOrEmpty(config.RepoName))
-                {
-                    DebugWindow.Log($"[FetchVersions] Skipping {repoLabel}: empty config");
-                    return entries;
-                }
 
-                var url = $"https://api.github.com/repos/{config.RepoOwner}/{config.RepoName}/releases?per_page=30";
+                var url = $"https://api.github.com/repos/{config.RepoOwner}/{config.RepoName}/releases?per_page=100";
                 DebugWindow.Log($"[FetchVersions] GET {url}");
                 var response = await GetWithRetryAsync(() => _httpClient, url);
                 DebugWindow.Log($"[FetchVersions] {repoLabel} → HTTP {(int)response.StatusCode}");
@@ -857,8 +882,17 @@ namespace OptiscalerClient.Services
 
                     bool isThisLatestStable = false;
                     bool isThisLatestBeta = false;
+                    bool isThisLatestNightly = false;
 
-                    if (isBeta)
+                    if (isNightly)
+                    {
+                        if (!latestNightlyMarked)
+                        {
+                            isThisLatestNightly = true;
+                            latestNightlyMarked = true;
+                        }
+                    }
+                    else if (isBeta)
                     {
                         if (!latestBetaMarked)
                         {
@@ -879,9 +913,11 @@ namespace OptiscalerClient.Services
                     {
                         Version = version,
                         DownloadUrl = downloadUrl,
-                        IsBeta = isBeta,
+                        IsBeta = isBeta || (!isNightly && isPrerelease),
+                        IsNightly = isNightly || IsNightlyVersion(version),
                         IsLatestStable = isThisLatestStable,
                         IsLatestBeta = isThisLatestBeta,
+                        IsLatestNightly = isThisLatestNightly,
                     });
                 }
 
@@ -1298,11 +1334,7 @@ namespace OptiscalerClient.Services
             _cachedOptiPatcherVersions = _optiPatcherCache.Releases
                 .Select(r => r.Version)
                 .Distinct()
-                // "rolling" is a continuously-updated build, not a dated release — always keep it first.
-                .OrderByDescending(v => string.Equals(v, "rolling", StringComparison.OrdinalIgnoreCase))
-                .ThenByDescending(ParseVersionForSort)
-                .ThenByDescending(ParseVersionSuffixValue)
-                .ThenByDescending(v => v, StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(v => v, VersionComparer.Instance)
                 .ToList();
             DebugWindow.Log($"[OptiPatcherCache] Rebuilt in-memory: {_cachedOptiPatcherVersions.Count} version(s), latest={_cachedLatestOptiPatcherVersion}");
         }
@@ -1356,19 +1388,10 @@ namespace OptiscalerClient.Services
             _cachedLatestFakenvapiVersion = _fakenvapiCache.Releases.FirstOrDefault(r => r.IsLatest)?.Version
                 ?? _fakenvapiCache.Releases.FirstOrDefault()?.Version;
 
-            static Version parseFakenvapiVer(string v)
-            {
-                var clean = v.TrimStart('v');
-                var dash = clean.IndexOf('-');
-                if (dash >= 0) clean = clean[..dash];
-                return Version.TryParse(clean, out var p) ? p : new Version(0, 0);
-            }
-
             _cachedFakenvapiVersions = _fakenvapiCache.Releases
                 .Select(r => r.Version)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderByDescending(v => parseFakenvapiVer(v))
-                .ThenByDescending(v => v, StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(v => v, VersionComparer.Instance)
                 .ToList();
             DebugWindow.Log($"[FakenvapiCache] Rebuilt in-memory: {_cachedFakenvapiVersions.Count} version(s), latest={_cachedLatestFakenvapiVersion}");
         }
@@ -1871,100 +1894,112 @@ namespace OptiscalerClient.Services
             try
             {
                 // 1. Try to get the download URL from the local releases cache first
-                string? cachedDownloadUrl = _releasesCache.Releases
+                string? downloadUrl = _releasesCache.Releases
                     .FirstOrDefault(r => string.Equals(r.Version, version, StringComparison.OrdinalIgnoreCase))
                     ?.DownloadUrl;
 
-                // 2. Try to retrieve release from GitHub API (stable repo → beta repo, with/without v prefix)
-                HttpResponseMessage? response = null;
-                string? json = null;
-                string repoSource = "";
-
                 bool apiAvailable = true;
-                try
+
+                if (!string.IsNullOrEmpty(downloadUrl))
                 {
-                    // Try stable repo with v prefix
-                    var url = $"https://api.github.com/repos/{_config.OptiScaler.RepoOwner}/{_config.OptiScaler.RepoName}/releases/tags/v{version}";
-                    DebugWindow.Log($"[Download] Trying stable repo (with v prefix): {url}");
-                    response = await GetWithRetryAsync(() => _httpClient, url, maxRetries: 2, timeoutSeconds: 20);
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        // Try stable repo without v prefix
-                        url = $"https://api.github.com/repos/{_config.OptiScaler.RepoOwner}/{_config.OptiScaler.RepoName}/releases/tags/{version}";
-                        DebugWindow.Log($"[Download] Trying stable repo (without v prefix): {url}");
-                        response = await GetWithRetryAsync(() => _httpClient, url, maxRetries: 2, timeoutSeconds: 20);
-                    }
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        // Try beta repo with v prefix
-                        url = $"https://api.github.com/repos/{_config.OptiScalerBetas.RepoOwner}/{_config.OptiScalerBetas.RepoName}/releases/tags/v{version}";
-                        DebugWindow.Log($"[Download] Trying beta repo (with v prefix): {url}");
-                        response = await GetWithRetryAsync(() => _httpClient, url, maxRetries: 2, timeoutSeconds: 20);
-                        repoSource = " (beta repo)";
-                    }
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        // Try beta repo without v prefix
-                        url = $"https://api.github.com/repos/{_config.OptiScalerBetas.RepoOwner}/{_config.OptiScalerBetas.RepoName}/releases/tags/{version}";
-                        DebugWindow.Log($"[Download] Trying beta repo (without v prefix): {url}");
-                        response = await GetWithRetryAsync(() => _httpClient, url, maxRetries: 2, timeoutSeconds: 20);
-                        repoSource = " (beta repo)";
-                    }
-
-                    if (response.IsSuccessStatusCode)
-                    {
-                        json = await response.Content.ReadAsStringAsync();
-                    }
+                    DebugWindow.Log($"[Download] Using cached download URL for v{version}: {downloadUrl}");
                 }
-                catch (Exception networkEx)
+                else
                 {
-                    apiAvailable = false;
-                    DebugWindow.Log($"[Download] GitHub API unreachable: {networkEx.Message}");
-                }
+                    // 2. Try to retrieve release from GitHub API (check prioritized repo based on version type)
+                    HttpResponseMessage? response = null;
+                    string? json = null;
+                    string repoSource = "";
 
-                string? downloadUrl = null;
-
-                // 3. Parse download URL from API response if available
-                if (json != null)
-                {
-                    DebugWindow.Log($"[Download] Release found{repoSource} for OptiScaler v{version}");
-                    using var doc = JsonDocument.Parse(json);
-
-                    if (doc.RootElement.TryGetProperty("assets", out var assets))
+                    try
                     {
-                        foreach (var asset in assets.EnumerateArray())
+                        var reposToCheck = new List<RepositoryConfig>();
+                        if (IsNightlyVersion(version))
                         {
-                            if (asset.TryGetProperty("browser_download_url", out var urlProp))
-                            {
-                                var assetUrl = urlProp.GetString();
-                                if (assetUrl != null && (assetUrl.EndsWith(".zip") || assetUrl.EndsWith(".7z")))
-                                {
-                                    downloadUrl = assetUrl;
-                                    DebugWindow.Log($"[Download] Found download asset: {Path.GetFileName(assetUrl)}");
+                            if (!string.IsNullOrEmpty(_config.OptiScalerNightlies.RepoOwner))
+                                reposToCheck.Add(_config.OptiScalerNightlies);
+                            reposToCheck.Add(_config.OptiScaler);
+                            reposToCheck.Add(_config.OptiScalerBetas);
+                        }
+                        else if (IsBetaVersion(version))
+                        {
+                            reposToCheck.Add(_config.OptiScalerBetas);
+                            reposToCheck.Add(_config.OptiScaler);
+                            if (!string.IsNullOrEmpty(_config.OptiScalerNightlies.RepoOwner))
+                                reposToCheck.Add(_config.OptiScalerNightlies);
+                        }
+                        else
+                        {
+                            reposToCheck.Add(_config.OptiScaler);
+                            reposToCheck.Add(_config.OptiScalerBetas);
+                            if (!string.IsNullOrEmpty(_config.OptiScalerNightlies.RepoOwner))
+                                reposToCheck.Add(_config.OptiScalerNightlies);
+                        }
 
-                                    // Update cached URL if different/missing
-                                    var cacheEntry = _releasesCache.Releases.FirstOrDefault(
-                                        r => string.Equals(r.Version, version, StringComparison.OrdinalIgnoreCase));
-                                    if (cacheEntry != null && string.IsNullOrEmpty(cacheEntry.DownloadUrl))
+                        foreach (var repo in reposToCheck)
+                        {
+                            if (string.IsNullOrEmpty(repo.RepoOwner) || string.IsNullOrEmpty(repo.RepoName))
+                                continue;
+
+                            // Try with 'v' prefix
+                            var urlWithV = $"https://api.github.com/repos/{repo.RepoOwner}/{repo.RepoName}/releases/tags/v{version}";
+                            DebugWindow.Log($"[Download] Trying {repo.RepoOwner}/{repo.RepoName} (with v prefix): {urlWithV}");
+                            response = await GetWithRetryAsync(() => _httpClient, urlWithV, maxRetries: 2, timeoutSeconds: 20);
+
+                            if (!response.IsSuccessStatusCode)
+                            {
+                                // Try without 'v' prefix
+                                var urlWithoutV = $"https://api.github.com/repos/{repo.RepoOwner}/{repo.RepoName}/releases/tags/{version}";
+                                DebugWindow.Log($"[Download] Trying {repo.RepoOwner}/{repo.RepoName} (without v prefix): {urlWithoutV}");
+                                response = await GetWithRetryAsync(() => _httpClient, urlWithoutV, maxRetries: 2, timeoutSeconds: 20);
+                            }
+
+                            if (response.IsSuccessStatusCode)
+                            {
+                                repoSource = $" ({repo.RepoName})";
+                                json = await response.Content.ReadAsStringAsync();
+                                break;
+                            }
+                        }
+                    }
+                    catch (Exception networkEx)
+                    {
+                        apiAvailable = false;
+                        DebugWindow.Log($"[Download] GitHub API unreachable: {networkEx.Message}");
+                    }
+
+                    // 3. Parse download URL from API response if available
+                    if (json != null)
+                    {
+                        DebugWindow.Log($"[Download] Release found{repoSource} for OptiScaler v{version}");
+                        using var doc = JsonDocument.Parse(json);
+
+                        if (doc.RootElement.TryGetProperty("assets", out var assets))
+                        {
+                            foreach (var asset in assets.EnumerateArray())
+                            {
+                                if (asset.TryGetProperty("browser_download_url", out var urlProp))
+                                {
+                                    var assetUrl = urlProp.GetString();
+                                    if (assetUrl != null && (assetUrl.EndsWith(".zip") || assetUrl.EndsWith(".7z")))
                                     {
-                                        cacheEntry.DownloadUrl = downloadUrl;
-                                        SaveReleasesCache();
+                                        downloadUrl = assetUrl;
+                                        DebugWindow.Log($"[Download] Found download asset: {Path.GetFileName(assetUrl)}");
+
+                                        // Update cached URL if different/missing
+                                        var cacheEntry = _releasesCache.Releases.FirstOrDefault(
+                                            r => string.Equals(r.Version, version, StringComparison.OrdinalIgnoreCase));
+                                        if (cacheEntry != null && string.IsNullOrEmpty(cacheEntry.DownloadUrl))
+                                        {
+                                            cacheEntry.DownloadUrl = downloadUrl;
+                                            SaveReleasesCache();
+                                        }
+                                        break;
                                     }
-                                    break;
                                 }
                             }
                         }
                     }
-                }
-
-                // 4. Fall back to cached URL if API didn't yield one
-                if (downloadUrl == null && !string.IsNullOrEmpty(cachedDownloadUrl))
-                {
-                    downloadUrl = cachedDownloadUrl;
-                    DebugWindow.Log($"[Download] Using cached download URL for v{version}: {downloadUrl}");
                 }
 
                 // 5. Nothing to download from — surface a friendly error
@@ -2240,14 +2275,10 @@ namespace OptiscalerClient.Services
                     }
                 }
             }
-            // Better to sort by length and alpha descending:
-            versions.Sort((a, b) =>
-            {
-                var comparison = b.Length.CompareTo(a.Length);
-                if (comparison == 0) return string.Compare(b, a, StringComparison.OrdinalIgnoreCase);
-                return comparison;
-            });
-            return versions;
+            return versions
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(v => v, VersionComparer.Instance)
+                .ToList();
         }
 
         public void DeleteOptiScalerCache(string version)

--- a/Views/BulkInstallWindow.axaml
+++ b/Views/BulkInstallWindow.axaml
@@ -221,7 +221,7 @@
                                                        Margin="0,-1,0,0"/>
                                         </Border>
                                     </StackPanel>
-                                    <Grid Name="GridOptiTabs" ColumnDefinitions="*,*">
+                                    <Grid Name="GridOptiTabs" ColumnDefinitions="*,*,*">
                                         <Button Name="BtnOptiStable"
                                                 Grid.Column="0"
                                                 Content="Stable"
@@ -240,10 +240,20 @@
                                                 HorizontalContentAlignment="Center"
                                                 FontSize="11"
                                                 Padding="8,5"
-                                                Margin="2,0,0,0"
+                                                Margin="2,0,2,0"
                                                 Click="BtnOptiBeta_Click"/>
-                                        <Button Name="BtnOptiCustom"
+                                        <Button Name="BtnOptiNightly"
                                                 Grid.Column="2"
+                                                Content="Nightly"
+                                                Classes="BtnSecondary"
+                                                HorizontalAlignment="Stretch"
+                                                HorizontalContentAlignment="Center"
+                                                FontSize="11"
+                                                Padding="8,5"
+                                                Margin="2,0,0,0"
+                                                Click="BtnOptiNightly_Click"/>
+                                        <Button Name="BtnOptiCustom"
+                                                Grid.Column="3"
                                                 Content="Custom"
                                                 Classes="BtnSecondary"
                                                 HorizontalAlignment="Stretch"

--- a/Views/BulkInstallWindow.axaml.cs
+++ b/Views/BulkInstallWindow.axaml.cs
@@ -32,6 +32,7 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
     private bool _isUpdatingProfiles = false;
     private const string NewProfileTag = "__new_profile__";
     private bool _optiShowingBeta;
+    private bool _optiShowingNightly;
     private bool _optiShowingCustom;
     private bool _optiTabInitialized;
     private BulkGamepadNavigationHelper? _gamepadHelper;
@@ -213,18 +214,28 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
             if (btnCustom != null) btnCustom.IsVisible = hasCustom;
             if (gridTabs != null)
                 gridTabs.ColumnDefinitions = hasCustom
-                    ? new ColumnDefinitions("*,*,*")
-                    : new ColumnDefinitions("*,*");
+                    ? new ColumnDefinitions("*,*,*,*")
+                    : new ColumnDefinitions("*,*,*");
 
             // Determine initial tab on first load
             if (!_optiTabInitialized)
             {
                 var configDefault = _componentService.EffectiveDefaultOptiScalerVersion;
-                _optiShowingBeta = !string.IsNullOrEmpty(configDefault) &&
-                                   _componentService.BetaVersions.Contains(configDefault);
+                _optiShowingNightly = !string.IsNullOrEmpty(configDefault) &&
+                                     (_componentService.IsNightlyVersion(configDefault) || _componentService.NightlyVersions.Contains(configDefault));
+                _optiShowingBeta = !string.IsNullOrEmpty(configDefault) && !_optiShowingNightly &&
+                                   (_componentService.IsBetaVersion(configDefault) || _componentService.BetaVersions.Contains(configDefault));
                 _optiShowingCustom = !string.IsNullOrEmpty(configDefault) &&
                                      customVersions.Contains(configDefault);
-                if (_optiShowingCustom) _optiShowingBeta = false;
+                if (_optiShowingCustom)
+                {
+                    _optiShowingBeta = false;
+                    _optiShowingNightly = false;
+                }
+                else if (_optiShowingNightly)
+                {
+                    _optiShowingBeta = false;
+                }
                 _optiTabInitialized = true;
             }
 
@@ -240,11 +251,8 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
     {
         var allVersions = _componentService.OptiScalerAvailableVersions;
         var betaVersions = _componentService.BetaVersions;
+        var nightlyVersions = _componentService.NightlyVersions;
         var customVersions = _componentService.CustomVersions;
-        var latestStable = _componentService.LatestStableVersion;
-        var latestBeta = _componentService.LatestBetaVersion;
-        string? latestInChannel = _optiShowingCustom ? null : (_optiShowingBeta ? latestBeta : latestStable);
-        string latestBadgeColor = _optiShowingBeta ? "#D4A017" : "#7C3AED";
 
         var cmb = this.FindControl<ComboBox>("CmbOptiVersion");
         if (cmb == null) return;
@@ -264,8 +272,16 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
         System.Collections.Generic.List<string> versionsToShow;
         if (_optiShowingCustom)
             versionsToShow = allVersions.Where(v => customVersions.Contains(v)).ToList();
+        else if (_optiShowingNightly)
+            versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && (_componentService.IsNightlyVersion(v) || nightlyVersions.Contains(v))).ToList();
+        else if (_optiShowingBeta)
+            versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && !_componentService.IsNightlyVersion(v) && !nightlyVersions.Contains(v) && (_componentService.IsBetaVersion(v) || betaVersions.Contains(v))).ToList();
         else
-            versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && betaVersions.Contains(v) == _optiShowingBeta).ToList();
+            versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && !_componentService.IsNightlyVersion(v) && !nightlyVersions.Contains(v) && !_componentService.IsBetaVersion(v) && !betaVersions.Contains(v)).ToList();
+
+        versionsToShow = versionsToShow.Distinct(StringComparer.OrdinalIgnoreCase)
+                                       .OrderByDescending(v => v, VersionComparer.Instance)
+                                       .ToList();
 
         if (versionsToShow.Count == 0)
         {
@@ -275,6 +291,9 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
             cmb.SelectionChanged += CmbOptiVersion_SelectionChanged;
             return;
         }
+
+        string? latestInChannel = _optiShowingCustom ? null : versionsToShow.FirstOrDefault();
+        string latestBadgeColor = _optiShowingNightly ? "#0284C7" : (_optiShowingBeta ? "#D4A017" : "#7C3AED");
 
         cmb.IsEnabled = true;
 
@@ -307,7 +326,11 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
         bool defaultInChannel = !string.IsNullOrEmpty(configDefault) &&
             (_optiShowingCustom
                 ? customVersions.Contains(configDefault)
-                : !customVersions.Contains(configDefault) && betaVersions.Contains(configDefault) == _optiShowingBeta);
+                : _optiShowingNightly
+                    ? (_componentService.IsNightlyVersion(configDefault) || nightlyVersions.Contains(configDefault))
+                    : _optiShowingBeta
+                        ? (!customVersions.Contains(configDefault) && !_componentService.IsNightlyVersion(configDefault) && !nightlyVersions.Contains(configDefault) && (_componentService.IsBetaVersion(configDefault) || betaVersions.Contains(configDefault)))
+                        : (!customVersions.Contains(configDefault) && !_componentService.IsNightlyVersion(configDefault) && !nightlyVersions.Contains(configDefault) && !_componentService.IsBetaVersion(configDefault) && !betaVersions.Contains(configDefault)));
         if (defaultInChannel)
         {
             for (int i = 0; i < cmb.Items.Count; i++)
@@ -329,6 +352,7 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
     {
         var btnStable = this.FindControl<Button>("BtnOptiStable");
         var btnBeta = this.FindControl<Button>("BtnOptiBeta");
+        var btnNightly = this.FindControl<Button>("BtnOptiNightly");
         var btnCustom = this.FindControl<Button>("BtnOptiCustom");
         if (btnStable == null || btnBeta == null) return;
 
@@ -339,26 +363,37 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
         {
             SetInactive(btnStable);
             SetInactive(btnBeta);
+            if (btnNightly != null) SetInactive(btnNightly);
             if (btnCustom != null) SetActive(btnCustom);
+        }
+        else if (_optiShowingNightly)
+        {
+            SetInactive(btnStable);
+            SetInactive(btnBeta);
+            if (btnNightly != null) SetActive(btnNightly);
+            if (btnCustom != null) SetInactive(btnCustom);
         }
         else if (_optiShowingBeta)
         {
             SetInactive(btnStable);
             SetActive(btnBeta);
+            if (btnNightly != null) SetInactive(btnNightly);
             if (btnCustom != null) SetInactive(btnCustom);
         }
         else
         {
             SetActive(btnStable);
             SetInactive(btnBeta);
+            if (btnNightly != null) SetInactive(btnNightly);
             if (btnCustom != null) SetInactive(btnCustom);
         }
     }
 
     private void BtnOptiStable_Click(object? sender, RoutedEventArgs e)
     {
-        if (!_optiShowingBeta && !_optiShowingCustom) return;
+        if (!_optiShowingBeta && !_optiShowingNightly && !_optiShowingCustom) return;
         _optiShowingBeta = false;
+        _optiShowingNightly = false;
         _optiShowingCustom = false;
         UpdateOptiChannelButtons();
         PopulateOptiVersionCombo();
@@ -368,6 +403,17 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
     {
         if (_optiShowingBeta) return;
         _optiShowingBeta = true;
+        _optiShowingNightly = false;
+        _optiShowingCustom = false;
+        UpdateOptiChannelButtons();
+        PopulateOptiVersionCombo();
+    }
+
+    private void BtnOptiNightly_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_optiShowingNightly) return;
+        _optiShowingNightly = true;
+        _optiShowingBeta = false;
         _optiShowingCustom = false;
         UpdateOptiChannelButtons();
         PopulateOptiVersionCombo();
@@ -378,6 +424,7 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
         if (_optiShowingCustom) return;
         _optiShowingCustom = true;
         _optiShowingBeta = false;
+        _optiShowingNightly = false;
         UpdateOptiChannelButtons();
         PopulateOptiVersionCombo();
     }
@@ -756,10 +803,12 @@ public partial class BulkInstallWindow : Window, IGamepadInputHost
         if (cmb == null) return;
 
         var selectedTag = (cmb?.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+        bool isNightly = !string.IsNullOrEmpty(selectedTag) &&
+            (_componentService.IsNightlyVersion(selectedTag) || _componentService.NightlyVersions.Contains(selectedTag));
         bool isBeta = !string.IsNullOrEmpty(selectedTag) && _componentService.BetaVersions.Contains(selectedTag);
 
-        // Disable Fakenvapi/NukemFG for any OptiScaler version >= 0.9 regardless of beta
-        bool includedInPackage = IsVersionGreaterOrEqual(selectedTag, 0, 9);
+        // Disable Fakenvapi/NukemFG for any OptiScaler version >= 0.9 regardless of beta, or for nightly builds
+        bool includedInPackage = isNightly || IsVersionGreaterOrEqual(selectedTag, 0, 9);
 
         var cmbFakenvapi = this.FindControl<ComboBox>("CmbFakenvapiVersion");
         var cmbNukemFG = this.FindControl<ComboBox>("CmbNukemFGVersion");

--- a/Views/CacheManagementWindow.axaml.cs
+++ b/Views/CacheManagementWindow.axaml.cs
@@ -221,6 +221,7 @@ namespace OptiscalerClient.Views
             var optiChildren = new StackPanel { Margin = new Thickness(20, 0, 0, 0), IsVisible = true };
             optiChildren.Children.Add(CreateSubButton("opti-stable", "Stable", "\uE78F"));
             optiChildren.Children.Add(CreateSubButton("opti-beta",   "Beta",   "\uE206"));
+            optiChildren.Children.Add(CreateSubButton("opti-nightly", "Nightly", "\uE708"));
             optiChildren.Children.Add(CreateSubButton("opti-custom", "Custom", "\uF41D"));
 
             optiButton.Click += (s, e) =>
@@ -429,29 +430,35 @@ namespace OptiscalerClient.Views
 
             switch (sectionId)
             {
-                case "opti-stable": RenderOptiScalerVersions(content, showBeta: false); break;
-                case "opti-beta":   RenderOptiScalerVersions(content, showBeta: true);  break;
-                case "opti-custom": RenderOptiScalerCustom(content); break;
-                case "optipatcher": RenderOptiPatcher(content); break;
-                case "fsr4":        RenderFsr4(content); break;
-                case "fakenvapi":   RenderFakenvapi(content); break;
-                case "nukemfg":     RenderNukemfg(content); break;
+                case "opti-stable":  RenderOptiScalerVersions(content, showBeta: false, showNightly: false); break;
+                case "opti-beta":    RenderOptiScalerVersions(content, showBeta: true,  showNightly: false); break;
+                case "opti-nightly": RenderOptiScalerVersions(content, showBeta: false, showNightly: true);  break;
+                case "opti-custom":  RenderOptiScalerCustom(content); break;
+                case "optipatcher":  RenderOptiPatcher(content); break;
+                case "fsr4":         RenderFsr4(content); break;
+                case "fakenvapi":    RenderFakenvapi(content); break;
+                case "nukemfg":      RenderNukemfg(content); break;
             }
         }
 
-        private void RenderOptiScalerVersions(StackPanel content, bool showBeta)
+        private void RenderOptiScalerVersions(StackPanel content, bool showBeta, bool showNightly = false)
         {
             content.Children.Add(CreateSetDefaultRow());
 
             var allVersions = _componentService.GetDownloadedOptiScalerVersions();
             var betaSet     = _componentService.BetaVersions;
+            var nightlySet  = _componentService.NightlyVersions;
             var customSet   = _componentService.CustomVersions;
 
             var filtered = allVersions.Where(v =>
             {
                 if (customSet.Contains(v)) return false;
-                return betaSet.Contains(v) == showBeta;
-            }).ToList();
+                if (showNightly) return _componentService.IsNightlyVersion(v) || nightlySet.Contains(v);
+                if (showBeta) return !_componentService.IsNightlyVersion(v) && !nightlySet.Contains(v) && (_componentService.IsBetaVersion(v) || betaSet.Contains(v));
+                return !_componentService.IsNightlyVersion(v) && !nightlySet.Contains(v) && !_componentService.IsBetaVersion(v) && !betaSet.Contains(v);
+            }).Distinct(StringComparer.OrdinalIgnoreCase)
+              .OrderByDescending(v => v, VersionComparer.Instance)
+              .ToList();
 
             if (filtered.Count == 0)
             {
@@ -664,13 +671,13 @@ namespace OptiscalerClient.Views
         // ── Version card ──────────────────────────────────────────────────────
 
         private static bool IsOptiSection(string sectionId) =>
-            sectionId is "opti-stable" or "opti-beta" or "opti-custom";
+            sectionId is "opti-stable" or "opti-beta" or "opti-nightly" or "opti-custom";
 
         private string? GetCurrentDefault()
         {
             return _currentSection switch
             {
-                "opti-stable" or "opti-beta" or "opti-custom" => _componentService.Config.DefaultOptiScalerVersion,
+                "opti-stable" or "opti-beta" or "opti-nightly" or "opti-custom" => _componentService.Config.DefaultOptiScalerVersion,
                 "optipatcher" => _componentService.Config.DefaultOptiPatcherVersion,
                 "fsr4" => _componentService.Config.DefaultExtrasVersion,
                 "fakenvapi" => _componentService.Config.DefaultFakenvapiVersion,
@@ -991,6 +998,7 @@ namespace OptiscalerClient.Views
             {
                 case "opti-stable":
                 case "opti-beta":
+                case "opti-nightly":
                 case "opti-custom":
                     _componentService.Config.DefaultOptiScalerVersion = _selectedVersion;
                     break;
@@ -1019,6 +1027,7 @@ namespace OptiscalerClient.Views
             {
                 case "opti-stable":
                 case "opti-beta":
+                case "opti-nightly":
                 case "opti-custom":
                     _componentService.Config.DefaultOptiScalerVersion = null;
                     break;

--- a/Views/ManageDefaultVersionsWindow.axaml
+++ b/Views/ManageDefaultVersionsWindow.axaml
@@ -64,7 +64,7 @@
                                                TextWrapping="Wrap"
                                                FontSize="{StaticResource FontSizeCaption}"/>
                                     <StackPanel Spacing="4" Margin="0,4,0,0">
-                                        <Grid Name="GridOptiDefaultTabs" ColumnDefinitions="*,*">
+                                        <Grid Name="GridOptiDefaultTabs" ColumnDefinitions="*,*,*">
                                             <Button Name="BtnOptiDefaultStable"
                                                     Grid.Column="0"
                                                     Content="Stable"
@@ -83,10 +83,20 @@
                                                     HorizontalContentAlignment="Center"
                                                     FontSize="11"
                                                     Padding="8,5"
-                                                    Margin="2,0,0,0"
+                                                    Margin="2,0,2,0"
                                                     Click="BtnOptiDefaultBeta_Click"/>
-                                            <Button Name="BtnOptiDefaultCustom"
+                                            <Button Name="BtnOptiDefaultNightly"
                                                     Grid.Column="2"
+                                                    Content="Nightly"
+                                                    Classes="BtnSecondary"
+                                                    HorizontalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Center"
+                                                    FontSize="11"
+                                                    Padding="8,5"
+                                                    Margin="2,0,0,0"
+                                                    Click="BtnOptiDefaultNightly_Click"/>
+                                            <Button Name="BtnOptiDefaultCustom"
+                                                    Grid.Column="3"
                                                     Content="Custom"
                                                     Classes="BtnSecondary"
                                                     HorizontalAlignment="Stretch"

--- a/Views/ManageDefaultVersionsWindow.axaml.cs
+++ b/Views/ManageDefaultVersionsWindow.axaml.cs
@@ -18,6 +18,7 @@ namespace OptiscalerClient.Views
         private readonly ComponentManagementService _componentService;
         private readonly IGpuDetectionService? _gpuService;
         private bool _optiDefaultShowingBeta;
+        private bool _optiDefaultShowingNightly;
         private bool _optiDefaultShowingCustom;
         private GamepadDialogNavigationHelper? _gamepadHelper;
 
@@ -79,14 +80,18 @@ namespace OptiscalerClient.Views
         {
             bool autoLatest = _componentService.Config.AutoLatestOptiScalerDefault;
 
-            // Determine if saved OptiScaler default is beta or custom (irrelevant while auto-latest is on)
+            // Determine if saved OptiScaler default is beta, nightly, or custom (irrelevant while auto-latest is on)
             var savedOptiDefault = _componentService.Config.DefaultOptiScalerVersion;
             var customVersions = _componentService.CustomVersions;
-            bool savedIsBeta = !autoLatest && !string.IsNullOrEmpty(savedOptiDefault) &&
-                               _componentService.BetaVersions.Contains(savedOptiDefault);
+            bool savedIsNightly = !autoLatest && !string.IsNullOrEmpty(savedOptiDefault) &&
+                                  (_componentService.IsNightlyVersion(savedOptiDefault) || _componentService.NightlyVersions.Contains(savedOptiDefault));
+            bool savedIsBeta = !autoLatest && !string.IsNullOrEmpty(savedOptiDefault) && !savedIsNightly &&
+                               (_componentService.IsBetaVersion(savedOptiDefault) || _componentService.BetaVersions.Contains(savedOptiDefault));
             bool savedIsCustom = !autoLatest && !string.IsNullOrEmpty(savedOptiDefault) &&
                                  customVersions.Contains(savedOptiDefault);
-            if (savedIsCustom) savedIsBeta = false;
+            if (savedIsCustom) { savedIsBeta = false; savedIsNightly = false; }
+            else if (savedIsNightly) { savedIsBeta = false; }
+            _optiDefaultShowingNightly = savedIsNightly;
             _optiDefaultShowingBeta = savedIsBeta;
             _optiDefaultShowingCustom = savedIsCustom;
 
@@ -97,11 +102,11 @@ namespace OptiscalerClient.Views
             if (btnCustom != null) btnCustom.IsVisible = hasCustom;
             if (gridTabs != null)
                 gridTabs.ColumnDefinitions = hasCustom
-                    ? new ColumnDefinitions("*,*,*")
-                    : new ColumnDefinitions("*,*");
+                    ? new ColumnDefinitions("*,*,*,*")
+                    : new ColumnDefinitions("*,*,*");
 
             UpdateOptiDefaultChannelButtons();
-            PopulateDefaultOptiScalerVersionCombo(showBeta: savedIsBeta, showCustom: savedIsCustom, restoreSaved: !autoLatest);
+            PopulateDefaultOptiScalerVersionCombo(showBeta: savedIsBeta, showNightly: savedIsNightly, showCustom: savedIsCustom, restoreSaved: !autoLatest);
             PopulateDefaultExtrasCombo();
             PopulateDefaultOptiPatcherCombo();
             UpdateOptiAutoLockState();
@@ -118,19 +123,21 @@ namespace OptiscalerClient.Views
             var cmb = this.FindControl<ComboBox>("CmbDefaultOptiScalerVersion");
             var btnStable = this.FindControl<Button>("BtnOptiDefaultStable");
             var btnBeta = this.FindControl<Button>("BtnOptiDefaultBeta");
+            var btnNightly = this.FindControl<Button>("BtnOptiDefaultNightly");
             var btnCustom = this.FindControl<Button>("BtnOptiDefaultCustom");
             var txtNote = this.FindControl<TextBlock>("TxtOptiAutoLatestNote");
 
             if (cmb != null) cmb.IsEnabled = !autoLatest;
             if (btnStable != null) btnStable.IsEnabled = !autoLatest;
             if (btnBeta != null) btnBeta.IsEnabled = !autoLatest;
+            if (btnNightly != null) btnNightly.IsEnabled = !autoLatest;
             if (btnCustom != null) btnCustom.IsEnabled = !autoLatest;
             if (txtNote != null) txtNote.IsVisible = autoLatest;
         }
 
         // ── OptiScaler Version ──────────────────────────────────────────────
 
-        private void PopulateDefaultOptiScalerVersionCombo(bool showBeta, bool restoreSaved, bool showCustom = false)
+        private void PopulateDefaultOptiScalerVersionCombo(bool showBeta, bool showNightly = false, bool restoreSaved = false, bool showCustom = false)
         {
             var cmb = this.FindControl<ComboBox>("CmbDefaultOptiScalerVersion");
             if (cmb == null) return;
@@ -139,28 +146,29 @@ namespace OptiscalerClient.Views
 
             var allVersions = _componentService.OptiScalerAvailableVersions;
             var betaSet = _componentService.BetaVersions;
+            var nightlySet = _componentService.NightlyVersions;
             var customSet = _componentService.CustomVersions;
-            var latestStable = _componentService.LatestStableVersion;
-            var latestBeta = _componentService.LatestBetaVersion;
 
-            foreach (var ver in allVersions)
+            System.Collections.Generic.List<string> versionsToShow;
+            if (showCustom)
+                versionsToShow = allVersions.Where(v => customSet.Contains(v)).ToList();
+            else if (showNightly)
+                versionsToShow = allVersions.Where(v => !customSet.Contains(v) && (_componentService.IsNightlyVersion(v) || nightlySet.Contains(v))).ToList();
+            else if (showBeta)
+                versionsToShow = allVersions.Where(v => !customSet.Contains(v) && !_componentService.IsNightlyVersion(v) && !nightlySet.Contains(v) && (_componentService.IsBetaVersion(v) || betaSet.Contains(v))).ToList();
+            else
+                versionsToShow = allVersions.Where(v => !customSet.Contains(v) && !_componentService.IsNightlyVersion(v) && !nightlySet.Contains(v) && !_componentService.IsBetaVersion(v) && !betaSet.Contains(v)).ToList();
+
+            versionsToShow = versionsToShow.Distinct(StringComparer.OrdinalIgnoreCase)
+                                           .OrderByDescending(v => v, VersionComparer.Instance)
+                                           .ToList();
+
+            string? latestInChannel = showCustom ? null : versionsToShow.FirstOrDefault();
+            string latestBadgeColor = showNightly ? "#0284C7" : (showBeta ? "#D4A017" : "#7C3AED");
+
+            foreach (var ver in versionsToShow)
             {
-                bool isBeta = betaSet.Contains(ver);
-                bool isCustom = customSet.Contains(ver);
-
-                if (showCustom)
-                {
-                    if (!isCustom) continue;
-                }
-                else
-                {
-                    if (isCustom) continue;
-                    if (isBeta != showBeta) continue;
-                }
-
-                bool isLatestInChannel = !showCustom && (showBeta
-                    ? ver == latestBeta
-                    : ver == latestStable);
+                bool isLatestInChannel = !showCustom && string.Equals(ver, latestInChannel, StringComparison.OrdinalIgnoreCase);
 
                 ComboBoxItem cbi;
                 if (isLatestInChannel)
@@ -175,7 +183,7 @@ namespace OptiscalerClient.Views
                     stack.Children.Add(new Border
                     {
                         CornerRadius = new CornerRadius(4),
-                        Background = new SolidColorBrush(Color.Parse(showBeta ? "#D4A017" : "#7C3AED")),
+                        Background = new SolidColorBrush(Color.Parse(latestBadgeColor)),
                         Padding = new Thickness(5, 1),
                         Child = new TextBlock
                         {
@@ -225,20 +233,32 @@ namespace OptiscalerClient.Views
 
         private void BtnOptiDefaultStable_Click(object? sender, RoutedEventArgs e)
         {
-            if (!_optiDefaultShowingBeta && !_optiDefaultShowingCustom) return;
+            if (!_optiDefaultShowingBeta && !_optiDefaultShowingNightly && !_optiDefaultShowingCustom) return;
             _optiDefaultShowingBeta = false;
+            _optiDefaultShowingNightly = false;
             _optiDefaultShowingCustom = false;
             UpdateOptiDefaultChannelButtons();
-            PopulateDefaultOptiScalerVersionCombo(showBeta: false, restoreSaved: false);
+            PopulateDefaultOptiScalerVersionCombo(showBeta: false, showNightly: false, restoreSaved: false);
         }
 
         private void BtnOptiDefaultBeta_Click(object? sender, RoutedEventArgs e)
         {
             if (_optiDefaultShowingBeta) return;
             _optiDefaultShowingBeta = true;
+            _optiDefaultShowingNightly = false;
             _optiDefaultShowingCustom = false;
             UpdateOptiDefaultChannelButtons();
-            PopulateDefaultOptiScalerVersionCombo(showBeta: true, restoreSaved: false);
+            PopulateDefaultOptiScalerVersionCombo(showBeta: true, showNightly: false, restoreSaved: false);
+        }
+
+        private void BtnOptiDefaultNightly_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_optiDefaultShowingNightly) return;
+            _optiDefaultShowingNightly = true;
+            _optiDefaultShowingBeta = false;
+            _optiDefaultShowingCustom = false;
+            UpdateOptiDefaultChannelButtons();
+            PopulateDefaultOptiScalerVersionCombo(showBeta: false, showNightly: true, restoreSaved: false);
         }
 
         private void BtnOptiDefaultCustom_Click(object? sender, RoutedEventArgs e)
@@ -246,14 +266,16 @@ namespace OptiscalerClient.Views
             if (_optiDefaultShowingCustom) return;
             _optiDefaultShowingCustom = true;
             _optiDefaultShowingBeta = false;
+            _optiDefaultShowingNightly = false;
             UpdateOptiDefaultChannelButtons();
-            PopulateDefaultOptiScalerVersionCombo(showBeta: false, showCustom: true, restoreSaved: false);
+            PopulateDefaultOptiScalerVersionCombo(showBeta: false, showNightly: false, showCustom: true, restoreSaved: false);
         }
 
         private void UpdateOptiDefaultChannelButtons()
         {
             var btnStable = this.FindControl<Button>("BtnOptiDefaultStable");
             var btnBeta = this.FindControl<Button>("BtnOptiDefaultBeta");
+            var btnNightly = this.FindControl<Button>("BtnOptiDefaultNightly");
             var btnCustom = this.FindControl<Button>("BtnOptiDefaultCustom");
             if (btnStable == null || btnBeta == null) return;
 
@@ -264,18 +286,28 @@ namespace OptiscalerClient.Views
             {
                 SetInactive(btnStable);
                 SetInactive(btnBeta);
+                if (btnNightly != null) SetInactive(btnNightly);
                 if (btnCustom != null) SetActive(btnCustom);
+            }
+            else if (_optiDefaultShowingNightly)
+            {
+                SetInactive(btnStable);
+                SetInactive(btnBeta);
+                if (btnNightly != null) SetActive(btnNightly);
+                if (btnCustom != null) SetInactive(btnCustom);
             }
             else if (_optiDefaultShowingBeta)
             {
                 SetInactive(btnStable);
                 SetActive(btnBeta);
+                if (btnNightly != null) SetInactive(btnNightly);
                 if (btnCustom != null) SetInactive(btnCustom);
             }
             else
             {
                 SetActive(btnStable);
                 SetInactive(btnBeta);
+                if (btnNightly != null) SetInactive(btnNightly);
                 if (btnCustom != null) SetInactive(btnCustom);
             }
         }

--- a/Views/ManageGameWindow.axaml
+++ b/Views/ManageGameWindow.axaml
@@ -363,7 +363,7 @@
                                     <TextBlock Text="{DynamicResource TxtVersionLbl}"
                                                Foreground="{StaticResource BrTextSecondary}"
                                                FontSize="{StaticResource FontSizeCaption}"/>
-                                    <Grid Name="GridOptiTabs" ColumnDefinitions="*,*">
+                                    <Grid Name="GridOptiTabs" ColumnDefinitions="*,*,*">
                                         <Button Name="BtnOptiStable"
                                                 Grid.Column="0"
                                                 Content="Stable"
@@ -382,10 +382,20 @@
                                                 HorizontalContentAlignment="Center"
                                                 FontSize="11"
                                                 Padding="8,5"
-                                                Margin="2,0,0,0"
+                                                Margin="2,0,2,0"
                                                 Click="BtnOptiBeta_Click"/>
-                                        <Button Name="BtnOptiCustom"
+                                        <Button Name="BtnOptiNightly"
                                                 Grid.Column="2"
+                                                Content="Nightly"
+                                                Classes="BtnSecondary"
+                                                HorizontalAlignment="Stretch"
+                                                HorizontalContentAlignment="Center"
+                                                FontSize="11"
+                                                Padding="8,5"
+                                                Margin="2,0,0,0"
+                                                Click="BtnOptiNightly_Click"/>
+                                        <Button Name="BtnOptiCustom"
+                                                Grid.Column="3"
                                                 Content="Custom"
                                                 Classes="BtnSecondary"
                                                 HorizontalAlignment="Stretch"

--- a/Views/ManageGameWindow.axaml.cs
+++ b/Views/ManageGameWindow.axaml.cs
@@ -55,8 +55,10 @@ namespace OptiscalerClient.Views
         private readonly IGpuDetectionService? _gpuService;
         private Window? _ownerWindow;
         private HashSet<string> _betaVersions = new();
+        private HashSet<string> _nightlyVersions = new();
         private HashSet<string> _customVersions = new();
         private bool _optiShowingBeta;
+        private bool _optiShowingNightly;
         private bool _optiShowingCustom;
         private bool _optiTabInitialized;
         private ComponentManagementService? _cachedComponentService;
@@ -454,6 +456,7 @@ namespace OptiscalerClient.Views
             AddRootNode(nodes, "BtnEditImage", 1, 1);
             AddRootNode(nodes, "BtnOptiStable", 1, 2);
             AddRootNode(nodes, "BtnOptiBeta", 1, 3);
+            AddRootNode(nodes, "BtnOptiNightly", 1, 4);
             AddRootNode(nodes, "BtnClose", 1, 5);
 
             AddRootNode(nodes, "BtnEditTitle", 2, 1);
@@ -570,7 +573,9 @@ namespace OptiscalerClient.Views
         private static bool IsOptiTabButton(string controlName)
         {
             return string.Equals(controlName, "BtnOptiStable", StringComparison.Ordinal)
-                   || string.Equals(controlName, "BtnOptiBeta", StringComparison.Ordinal);
+                   || string.Equals(controlName, "BtnOptiBeta", StringComparison.Ordinal)
+                   || string.Equals(controlName, "BtnOptiNightly", StringComparison.Ordinal)
+                   || string.Equals(controlName, "BtnOptiCustom", StringComparison.Ordinal);
         }
 
         private IEnumerable<string> GetRootNeighborCandidates(string currentName, NavigationDirection direction)
@@ -592,14 +597,18 @@ namespace OptiscalerClient.Views
                 ("CmbOptiVersion", NavigationDirection.Down) => new[] { "CmbInjectionMethod", "CmbProfile" },
 
                 ("BtnOptiStable", NavigationDirection.Down) => new[] { "CmbOptiVersion" },
-                ("BtnOptiStable", NavigationDirection.Right) => new[] { "BtnOptiBeta", "CmbExtrasVersion" },
+                ("BtnOptiStable", NavigationDirection.Right) => new[] { "BtnOptiBeta", "BtnOptiNightly", "CmbExtrasVersion" },
 
                 ("BtnOptiBeta", NavigationDirection.Left) => new[] { "BtnOptiStable" },
-                ("BtnOptiBeta", NavigationDirection.Right) => new[] { "CmbExtrasVersion" },
+                ("BtnOptiBeta", NavigationDirection.Right) => new[] { "BtnOptiNightly", "CmbExtrasVersion" },
                 ("BtnOptiBeta", NavigationDirection.Down) => new[] { "CmbOptiVersion" },
 
+                ("BtnOptiNightly", NavigationDirection.Left) => new[] { "BtnOptiBeta", "BtnOptiStable" },
+                ("BtnOptiNightly", NavigationDirection.Right) => new[] { "CmbExtrasVersion" },
+                ("BtnOptiNightly", NavigationDirection.Down) => new[] { "CmbOptiVersion" },
+
                 ("CmbExtrasVersion", NavigationDirection.Left) => new[] { "CmbOptiVersion" },
-                ("CmbExtrasVersion", NavigationDirection.Up) => new[] { "BtnOptiBeta", "BtnOptiStable" },
+                ("CmbExtrasVersion", NavigationDirection.Up) => new[] { "BtnOptiNightly", "BtnOptiBeta", "BtnOptiStable" },
                 ("CmbExtrasVersion", NavigationDirection.Right) => new[] { "CmbFakenvapiVersion" },
                 ("CmbExtrasVersion", NavigationDirection.Down) => new[] { "CmbOptiPatcherVersion" },
 
@@ -651,6 +660,10 @@ namespace OptiscalerClient.Views
         {
             var stable = this.FindControl<Button>("BtnOptiStable");
             var beta = this.FindControl<Button>("BtnOptiBeta");
+            var nightly = this.FindControl<Button>("BtnOptiNightly");
+
+            if (nightly?.IsVisible == true && nightly.IsEnabled && nightly.Classes.Contains("BtnPrimary"))
+                return "BtnOptiNightly";
 
             if (beta?.IsVisible == true && beta.IsEnabled && beta.Classes.Contains("BtnPrimary"))
                 return "BtnOptiBeta";
@@ -660,6 +673,9 @@ namespace OptiscalerClient.Views
 
             if (beta?.IsVisible == true && beta.IsEnabled)
                 return "BtnOptiBeta";
+
+            if (nightly?.IsVisible == true && nightly.IsEnabled)
+                return "BtnOptiNightly";
 
             return string.Empty;
         }
@@ -1026,6 +1042,7 @@ namespace OptiscalerClient.Views
         {
             _cachedComponentService = componentService;
             _betaVersions = componentService.BetaVersions;
+            _nightlyVersions = componentService.NightlyVersions;
             _customVersions = componentService.CustomVersions;
 
             // Show/hide Custom tab based on whether custom versions exist
@@ -1035,16 +1052,17 @@ namespace OptiscalerClient.Views
             if (btnCustom != null) btnCustom.IsVisible = hasCustom;
             if (gridTabs != null)
                 gridTabs.ColumnDefinitions = hasCustom
-                    ? new ColumnDefinitions("*,*,*")
-                    : new ColumnDefinitions("*,*");
+                    ? new ColumnDefinitions("*,*,*,*")
+                    : new ColumnDefinitions("*,*,*");
 
             // Determine initial tab only on the first load
             if (!_optiTabInitialized)
             {
                 var configDefault = componentService.EffectiveDefaultOptiScalerVersion;
-                _optiShowingBeta = !string.IsNullOrEmpty(configDefault) && _betaVersions.Contains(configDefault);
+                _optiShowingNightly = !string.IsNullOrEmpty(configDefault) && (componentService.IsNightlyVersion(configDefault) || _nightlyVersions.Contains(configDefault));
+                _optiShowingBeta = !string.IsNullOrEmpty(configDefault) && !_optiShowingNightly && (componentService.IsBetaVersion(configDefault) || _betaVersions.Contains(configDefault));
                 _optiShowingCustom = !string.IsNullOrEmpty(configDefault) && _customVersions.Contains(configDefault);
-                if (_optiShowingCustom) _optiShowingBeta = false;
+                if (_optiShowingCustom) { _optiShowingBeta = false; _optiShowingNightly = false; }
                 _optiTabInitialized = true;
             }
 
@@ -1070,12 +1088,25 @@ namespace OptiscalerClient.Views
         {
             var allVersions = componentService.OptiScalerAvailableVersions;
             var betaVersions = componentService.BetaVersions;
+            var nightlyVersions = componentService.NightlyVersions;
             var customVersions = _customVersions;
-            var latestStable = componentService.LatestStableVersion;
-            var latestBeta = componentService.LatestBetaVersion;
 
-            string? latestInChannel = _optiShowingCustom ? null : (_optiShowingBeta ? latestBeta : latestStable);
-            string latestBadgeColor = _optiShowingBeta ? "#D4A017" : "#7C3AED";
+            System.Collections.Generic.List<string> versionsToShow;
+            if (_optiShowingCustom)
+                versionsToShow = allVersions.Where(v => customVersions.Contains(v)).ToList();
+            else if (_optiShowingNightly)
+                versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && (componentService.IsNightlyVersion(v) || nightlyVersions.Contains(v))).ToList();
+            else if (_optiShowingBeta)
+                versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && !componentService.IsNightlyVersion(v) && !nightlyVersions.Contains(v) && (componentService.IsBetaVersion(v) || betaVersions.Contains(v))).ToList();
+            else
+                versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && !componentService.IsNightlyVersion(v) && !nightlyVersions.Contains(v) && !componentService.IsBetaVersion(v) && !betaVersions.Contains(v)).ToList();
+
+            versionsToShow = versionsToShow.Distinct(StringComparer.OrdinalIgnoreCase)
+                                           .OrderByDescending(v => v, VersionComparer.Instance)
+                                           .ToList();
+
+            string? latestInChannel = _optiShowingCustom ? null : versionsToShow.FirstOrDefault();
+            string latestBadgeColor = _optiShowingNightly ? "#0284C7" : (_optiShowingBeta ? "#D4A017" : "#7C3AED");
 
             var cmbOptiVersion = this.FindControl<ComboBox>("CmbOptiVersion");
             if (cmbOptiVersion == null) return;
@@ -1091,12 +1122,6 @@ namespace OptiscalerClient.Views
                 cmbOptiVersion.SelectionChanged += CmbOptiVersion_SelectionChanged;
                 return;
             }
-
-            System.Collections.Generic.List<string> versionsToShow;
-            if (_optiShowingCustom)
-                versionsToShow = allVersions.Where(v => customVersions.Contains(v)).ToList();
-            else
-                versionsToShow = allVersions.Where(v => !customVersions.Contains(v) && betaVersions.Contains(v) == _optiShowingBeta).ToList();
 
             if (versionsToShow.Count == 0)
             {
@@ -1139,7 +1164,11 @@ namespace OptiscalerClient.Views
             bool defaultInChannel = !string.IsNullOrEmpty(configDefault) &&
                 (_optiShowingCustom
                     ? customVersions.Contains(configDefault)
-                    : !customVersions.Contains(configDefault) && betaVersions.Contains(configDefault) == _optiShowingBeta);
+                    : _optiShowingNightly
+                        ? (!customVersions.Contains(configDefault) && (componentService.IsNightlyVersion(configDefault) || nightlyVersions.Contains(configDefault)))
+                        : _optiShowingBeta
+                            ? (!componentService.IsNightlyVersion(configDefault) && !nightlyVersions.Contains(configDefault) && (componentService.IsBetaVersion(configDefault) || betaVersions.Contains(configDefault)))
+                            : (!customVersions.Contains(configDefault) && !componentService.IsNightlyVersion(configDefault) && !nightlyVersions.Contains(configDefault) && !componentService.IsBetaVersion(configDefault) && !betaVersions.Contains(configDefault)));
             if (defaultInChannel)
             {
                 for (int i = 0; i < cmbOptiVersion.Items.Count; i++)
@@ -1162,6 +1191,7 @@ namespace OptiscalerClient.Views
         {
             var btnStable = this.FindControl<Button>("BtnOptiStable");
             var btnBeta = this.FindControl<Button>("BtnOptiBeta");
+            var btnNightly = this.FindControl<Button>("BtnOptiNightly");
             var btnCustom = this.FindControl<Button>("BtnOptiCustom");
             if (btnStable == null || btnBeta == null) return;
 
@@ -1172,26 +1202,37 @@ namespace OptiscalerClient.Views
             {
                 SetInactive(btnStable);
                 SetInactive(btnBeta);
+                if (btnNightly != null) SetInactive(btnNightly);
                 if (btnCustom != null) SetActive(btnCustom);
+            }
+            else if (_optiShowingNightly)
+            {
+                SetInactive(btnStable);
+                SetInactive(btnBeta);
+                if (btnNightly != null) SetActive(btnNightly);
+                if (btnCustom != null) SetInactive(btnCustom);
             }
             else if (_optiShowingBeta)
             {
                 SetInactive(btnStable);
                 SetActive(btnBeta);
+                if (btnNightly != null) SetInactive(btnNightly);
                 if (btnCustom != null) SetInactive(btnCustom);
             }
             else
             {
                 SetActive(btnStable);
                 SetInactive(btnBeta);
+                if (btnNightly != null) SetInactive(btnNightly);
                 if (btnCustom != null) SetInactive(btnCustom);
             }
         }
 
         private void BtnOptiStable_Click(object? sender, RoutedEventArgs e)
         {
-            if (!_optiShowingBeta && !_optiShowingCustom) return;
+            if (!_optiShowingBeta && !_optiShowingNightly && !_optiShowingCustom) return;
             _optiShowingBeta = false;
+            _optiShowingNightly = false;
             _optiShowingCustom = false;
             UpdateOptiChannelButtons();
             if (_cachedComponentService != null)
@@ -1202,6 +1243,18 @@ namespace OptiscalerClient.Views
         {
             if (_optiShowingBeta) return;
             _optiShowingBeta = true;
+            _optiShowingNightly = false;
+            _optiShowingCustom = false;
+            UpdateOptiChannelButtons();
+            if (_cachedComponentService != null)
+                PopulateOptiVersionCombo(_cachedComponentService);
+        }
+
+        private void BtnOptiNightly_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_optiShowingNightly) return;
+            _optiShowingNightly = true;
+            _optiShowingBeta = false;
             _optiShowingCustom = false;
             UpdateOptiChannelButtons();
             if (_cachedComponentService != null)
@@ -1213,6 +1266,7 @@ namespace OptiscalerClient.Views
             if (_optiShowingCustom) return;
             _optiShowingCustom = true;
             _optiShowingBeta = false;
+            _optiShowingNightly = false;
             UpdateOptiChannelButtons();
             if (_cachedComponentService != null)
                 PopulateOptiVersionCombo(_cachedComponentService);
@@ -1489,10 +1543,11 @@ namespace OptiscalerClient.Views
 
             var selectedTag = (cmb?.SelectedItem as ComboBoxItem)?.Tag?.ToString();
             bool isBeta = !string.IsNullOrEmpty(selectedTag) && _betaVersions.Contains(selectedTag);
+            bool isNightly = !string.IsNullOrEmpty(selectedTag) && (_nightlyVersions.Contains(selectedTag) || selectedTag.StartsWith("nightly", StringComparison.OrdinalIgnoreCase));
 
-            // Disable Fakenvapi/NukemFG for any OptiScaler version >= 0.9 (included in package),
+            // Disable Fakenvapi/NukemFG for any OptiScaler version >= 0.9 or nightly (included in package),
             // regardless of whether it's a beta or stable build.
-            bool includedInPackage = IsVersionGreaterOrEqual(selectedTag, 0, 9);
+            bool includedInPackage = isNightly || IsVersionGreaterOrEqual(selectedTag, 0, 9);
 
             var cmbFakenvapi = this.FindControl<ComboBox>("CmbFakenvapiVersion");
             var cmbNukemFG = this.FindControl<ComboBox>("CmbNukemFGVersion");
@@ -3126,11 +3181,12 @@ namespace OptiscalerClient.Views
             var cmb = sender as ComboBox;
             UpdateCheckboxStatesForVersion(cmb);
 
-            // Only configure additional components if not a beta version
+            // Only configure additional components if not a beta or nightly version
             var selectedTag = (cmb?.SelectedItem as ComboBoxItem)?.Tag?.ToString();
             bool isBeta = !string.IsNullOrEmpty(selectedTag) && _betaVersions.Contains(selectedTag);
+            bool isNightly = !string.IsNullOrEmpty(selectedTag) && (_nightlyVersions.Contains(selectedTag) || selectedTag.StartsWith("nightly", StringComparison.OrdinalIgnoreCase));
 
-            if (!isBeta)
+            if (!isBeta && !isNightly)
             {
                 ConfigureAdditionalComponents();
             }
@@ -3148,11 +3204,12 @@ namespace OptiscalerClient.Views
             var cmbNukemFG = this.FindControl<ComboBox>("CmbNukemFGVersion");
 
             // Do not re-enable these controls when the selected OptiScaler version already
-            // bundles fakenvapi and nukemfg (>= 0.9). UpdateCheckboxStatesForVersion owns
+            // bundles fakenvapi and nukemfg (>= 0.9 or nightly). UpdateCheckboxStatesForVersion owns
             // the disabled state for those versions.
             var cmbOptiVersion = this.FindControl<ComboBox>("CmbOptiVersion");
             var selectedOptiTag = (cmbOptiVersion?.SelectedItem as ComboBoxItem)?.Tag?.ToString();
-            if (IsVersionGreaterOrEqual(selectedOptiTag, 0, 9))
+            if ((!string.IsNullOrEmpty(selectedOptiTag) && selectedOptiTag.StartsWith("nightly", StringComparison.OrdinalIgnoreCase)) ||
+                IsVersionGreaterOrEqual(selectedOptiTag, 0, 9))
                 return;
 
             if (gpu != null && gpu.Vendor == GpuVendor.NVIDIA)

--- a/config.json
+++ b/config.json
@@ -15,6 +15,10 @@
         "RepoOwner": "Optiscaler-Client",
         "RepoName": "OptiScaler-Betas"
     },
+    "OptiScalerNightlies": {
+        "RepoOwner": "optiscaler",
+        "RepoName": "OptiScaler-nightly"
+    },
     "OptiScalerExtras": {
         "RepoOwner": "Optiscaler-Client",
         "RepoName": "OptiScaler-Extras"


### PR DESCRIPTION
# What this does
- **OptiScaler Nightly Channel**: Adds support for OptiScaler nightly builds fetched from [`optiscaler/OptiScaler-nightly`](https://github.com/optiscaler/OptiScaler-nightly).
    - **UI Integration**: Introduces a dedicated **Nightly** channel button and version dropdown across all relevant views:
      - Game Management window (`ManageGameWindow`)
      - Bulk Installation window (`BulkInstallWindow`)
      - Default Versions configuration (`ManageDefaultVersionsWindow`)
      - Cache Management view (`CacheManagementWindow`)
    - **Version Badges & Ordering**:
      - Implements a unified `VersionComparer` ensuring all channels (Stable, Beta, Nightly, OptiPatcher, and Fakenvapi) strictly display releases from newest to oldest.
      - Fixes prerelease ordering (e.g. `pre4` > `pre3`) and automatically tags the newest release in each channel with the `LATEST` badge.
    - **Optimized Asset Downloads**: Uses cached download asset URLs directly to eliminate redundant GitHub API calls, prioritizing the matching channel repository and avoiding rate limit issues.
    - **Gamepad Navigation**: Adds full D-pad left/right navigation support between Stable, Beta, Nightly, and Custom tabs.
 
<img width="253" height="329" alt="image" src="https://github.com/user-attachments/assets/6bcfb7b3-d40e-46c2-9538-aaf8573f6558" />
